### PR TITLE
Fix permissions problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ cd openwrt
 ./scripts/feeds install -a
 
 git clone https://github.com/ffulm/firmware.git
-cp -rf firmware/files firmware/package .
+chmod -R +rX firmware/files/www
+cp -rfp firmware/files firmware/package .
 git am --whitespace=nowarn firmware/patches/openwrt/*.patch
 cd feeds/routing && git am --whitespace=nowarn ../../firmware/patches/routing/*.patch && cd -
 cd feeds/packages && git am --whitespace=nowarn ../../firmware/patches/packages/*.patch && cd -


### PR DESCRIPTION
Copying the files should not honor the umask. The permissions of files
under openwrt/files are preserved when the firmware image is built,
i.e., if the files are not world readable, then the webserver won't
work.
