### PR TITLE
Update Dockerfile (pin to debian:11)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:11
 RUN apt-get update; \
   apt-get install --no-install-recommends -y subversion g++ zlib1g-dev build-essential git python time libncurses5-dev gawk gettext unzip file libssl-dev wget; \
   apt-get install --no-install-recommends -y ca-certificates; \


### PR DESCRIPTION
Update Dockerfile (pin to debian:11)

with stabel it was no longer possible for me to build the image because some packages were no longer available in stable